### PR TITLE
Standardized file formats

### DIFF
--- a/champc_lib/build.py
+++ b/champc_lib/build.py
@@ -4,6 +4,7 @@ import json
 import importlib
 import tempfile
 import itertools
+import champc_lib.utils as utils
 
 def parse_json(fname):
     with open(fname, "r") as rfp:
@@ -14,7 +15,7 @@ def parse_json(fname):
 
 def parse_targets_file(build_list, config_path):
     with open(build_list) as build_file:
-      for line in filter(lambda l: not l.startswith('#'),  build_file):
+      for line in utils.filter_comments_and_blanks(build_file):
           target = os.path.join(config_path, line.strip())
           if os.path.exists(target):
               print("Found configuration", target)

--- a/champc_lib/config_env.py
+++ b/champc_lib/config_env.py
@@ -21,27 +21,22 @@ class env_config:
  
   def load_env_config(self, config_name):
     if not os.path.exists(config_name):
-      print("ERROR: CONTROL CONFIG FILE DOES NOT EXIST\nFile: " + config_name)
-      exit()
+      sys.exit("ERROR: CONTROL CONFIG FILE DOES NOT EXIST\nFile: " + config_name)
 
-    config_file = open(config_name, "r")
+    with open(config_name, "r") as config_file:
+        for line in utils.filter_comments_and_blanks(config_file):
+            key, delim, value = line.partition('=')
+            if delim != '=':
+                sys.exit('Error parsing line: '+line)
 
-    for line in config_file:
-      if line[0] == "#" or len(line) == 1:
-        continue
+            key = key.strip()
+            value = value.strip()
 
-      sline = line.strip().split("=")
+            if key in self.fields.keys():
+                sys.exit("ERROR: REPEATING CONFIGURATION FIELD: "+ key)
 
-      for a in range(0,len(sline)):
-        sline[a] = sline[a].strip(" ")
-        sline[a] = sline[a].strip("\n")
+            self.fields[key] = value
 
-      if sline[0] in self.fields.keys():
-        print("ERROR: REPEATING CONFIGURATION FIELD: "+ sline[0] +"\n")
-        exit()
-      
-      self.fields[sline[0]] = sline[1]
-     
   def load_launch_template(self):
 
     if not os.path.exists(self.fields["launch_template"]):

--- a/champc_lib/launch.py
+++ b/champc_lib/launch.py
@@ -4,6 +4,7 @@ from datetime import date
 import time 
 import subprocess
 import re
+import champc_lib.utils as utils
 
 def check_load(env_con):
   username = env_con.fields["username"]
@@ -99,12 +100,10 @@ def launch_handler(env_con):
 
   with open(env_con.fields["binary_list"], "r") as binary_list_file:
     #gather each binary 
-    for line in filter(lambda l: not l.startswith('#'),  binary_list_file):
-      binaries.append(line.strip())
+    binaries = list(utils.filter_comments_and_blanks(binary_list_file))
 
   with open(env_con.fields["workload_list"], "r") as workloads_list_file:
-    for line in filter(lambda l: not l.startswith('#'),  workloads_list_file):
-      workloads.append(line.strip())
+    workloads = list(utils.filter_comments_and_blanks(workloads_list_file))
 
  
   #workload director

--- a/champc_lib/utils.py
+++ b/champc_lib/utils.py
@@ -25,3 +25,7 @@ def check_str_float(ent):
     return True
   except ValueError:
     return False
+
+def filter_comments_and_blanks(file_iter):
+    trimmed_lines = (l.partition('#')[0].strip() for l in file_iter)
+    yield from (l for l in trimmed_lines if len(l) > 0)


### PR DESCRIPTION
This patch standardizes a few places where files are read by routing them through the same parsing function. It also extends the file format slightly. Previously, comments were allowed if `#` were the first character in the line. Now, comments are allowed to trail lines, as below

    my_key = my_value #Set my_key to my_value

Furthermore, blank lines are skipped in all files.